### PR TITLE
Add Array Overlap Operator

### DIFF
--- a/src/languages/PostgreSqlFormatter.js
+++ b/src/languages/PostgreSqlFormatter.js
@@ -530,6 +530,7 @@ export default class PostgreSqlFormatter extends Formatter {
         '!~',
         '!!',
         '||',
+        '&&',
       ],
     });
   }


### PR DESCRIPTION
### Description

<!-- Quick Summary -->

This PR adds the array overlap operator, `&&`, to the list of known operators. This operator gets split by a space, `& &`, during formatting without this change.

#### Ticket

N/A

### Screenshots

<!-- For UI code -->N/A

### Testing

<!-- How was this tested? Pick option below, or write your own -->

Tested this commit on a branch using this operator to ensure formatting works.
