### PR TITLE
[No-JIRA] Disable all webpack builds

### DIFF
--- a/package.json
+++ b/package.json
@@ -64,7 +64,7 @@
     "test": "jest",
     "test:watch": "npm run test -- --watch",
     "check": "npm run pretty:check && npm run lint && npm run test",
-    "build": "npm run build:commonjs && npm run build:umd && npm run build:umd:min",
+    "build": "npm run build:commonjs",
     "build:commonjs": "babel src --out-dir lib",
     "build:umd": "webpack --config webpack.dev.js",
     "build:umd:min": "webpack --config webpack.prod.js",

--- a/webpack.common.js
+++ b/webpack.common.js
@@ -7,7 +7,7 @@ module.exports = {
     filename: 'sql-formatter.js',
     library: 'sqlFormatter',
     libraryTarget: 'umd',
-    hashFunction: 'md5',
+    hashFunction: 'xxhash64',
   },
   module: {
     rules: [

--- a/webpack.common.js
+++ b/webpack.common.js
@@ -7,7 +7,7 @@ module.exports = {
     filename: 'sql-formatter.js',
     library: 'sqlFormatter',
     libraryTarget: 'umd',
-    hashFunction: 'xxhash64',
+    hashFunction: 'sha256',
   },
   module: {
     rules: [
@@ -17,8 +17,5 @@ module.exports = {
         use: ['babel-loader'],
       },
     ],
-  },
-  experiments: {
-    futureDefaults: true,
   },
 };

--- a/webpack.common.js
+++ b/webpack.common.js
@@ -7,7 +7,7 @@ module.exports = {
     filename: 'sql-formatter.js',
     library: 'sqlFormatter',
     libraryTarget: 'umd',
-    hashFunction: 'sha256',
+    hashFunction: 'md5',
   },
   module: {
     rules: [

--- a/webpack.common.js
+++ b/webpack.common.js
@@ -7,7 +7,6 @@ module.exports = {
     filename: 'sql-formatter.js',
     library: 'sqlFormatter',
     libraryTarget: 'umd',
-    hashFunction: 'xxhash64',
   },
   module: {
     rules: [

--- a/webpack.common.js
+++ b/webpack.common.js
@@ -7,6 +7,7 @@ module.exports = {
     filename: 'sql-formatter.js',
     library: 'sqlFormatter',
     libraryTarget: 'umd',
+    hashFunction: 'xxhash64',
   },
   module: {
     rules: [

--- a/webpack.common.js
+++ b/webpack.common.js
@@ -18,4 +18,7 @@ module.exports = {
       },
     ],
   },
+  experiments: {
+    futureDefaults: true,
+  },
 };


### PR DESCRIPTION
### Description

There are some issues with the current version of Webpack we use here and Node version 18.x, mainly because it tries to use an unsupported algorithm on this new version of node. There are workarounds for the initial issue, which is using `xxhash64` as the hashing algorithm, but after that step passes, `babel-loader` also fails because of a similar issue.

I decided to disable any build depending on Webpack because I could not solve that last `babel-loader` issue without making any drastic change, and also because we don't need those builds, the script we have that use this package use the main, commonjs build, which is still enabled after the changes done in this PR.

#### Ticket

N/A

### Screenshots

<!-- For UI code -->N/A

### Testing

Tested using the commit hash on the services repo for updating the package and all packages update successfully. and also the script that depend on this package are still running correctly.
