### PR TITLE
[PT-1753] Add Support for Postgres Trigram Distance Operators

### DIFF
--- a/src/languages/PostgreSqlFormatter.js
+++ b/src/languages/PostgreSqlFormatter.js
@@ -531,6 +531,11 @@ export default class PostgreSqlFormatter extends Formatter {
         '!!',
         '||',
         '&&',
+        '<->',
+        '<<->',
+        '<->>',
+        '<<<->',
+        '<->>>',
       ],
     });
   }


### PR DESCRIPTION
This PR adds support for the distance operators from the `pg_trgm` plugin. See [here](https://github.com/DispatchHealth/services/pull/6914/files#diff-4204e91c8e4504de2c03986853216ad89ca6ac3edc35e4db1e0f9462c80f9687R191) for context.